### PR TITLE
feat: Refactor notary. Detect when running cargo test to conditionally run thread termination code. Setup logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+output.log
 /target/
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ethereum-types = "0.3.0"
 ethcore-bytes = "0.1.0"
 tiny-keccak = "1.3"
 log = { version = "0.4.1", features = ["max_level_debug", "release_max_level_warn"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [badges]
 travis-ci = { repository = "Drops-of-Diamond/Diamond-drops", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/lib.rs"
 ethereum-types = "0.3.0"
 ethcore-bytes = "0.1.0"
 tiny-keccak = "1.3"
+log = { version = "0.4.1", features = ["max_level_debug", "release_max_level_warn"] }
 
 [badges]
 travis-ci = { repository = "Drops-of-Diamond/Diamond-drops", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ethcore-bytes = "0.1.0"
 tiny-keccak = "1.3"
 log = { version = "0.4.1", features = ["max_level_debug", "release_max_level_warn"] }
 chrono = { version = "0.4", features = ["serde"] }
+fern = "0.5"
 
 [badges]
 travis-ci = { repository = "Drops-of-Diamond/Diamond-drops", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ethcore-bytes = "0.1.0"
 tiny-keccak = "1.3"
 log = { version = "0.4.1", features = ["max_level_debug", "release_max_level_warn"] }
 chrono = { version = "0.4", features = ["serde"] }
-fern = "0.5"
+fern = { version = "0.5", features = ["colored"] }
 
 [badges]
 travis-ci = { repository = "Drops-of-Diamond/Diamond-drops", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ See [here](https://github.com/Drops-of-Diamond/diamond_drops/wiki/Introduction-a
     cargo test
     ```
 
+  * Build and show Docs
+    ```bash
+    cargo build;
+    cargo doc --open
+    ```
+
 See this wiki article [here](https://github.com/Drops-of-Diamond/diamond_drops/wiki/Contributing-guidelines).
 
 ### View UML Diagram

--- a/src/cli/config_env.rs
+++ b/src/cli/config_env.rs
@@ -4,18 +4,18 @@ pub fn get_env() -> String {
     let key = "RUST_ENV";
     match env::var(key) {
         Ok(val) => {
-            println!("Found environment variable key {}: {:?}", key, val);
+            debug!("Found environment variable key {}: {:?}", key, val);
             val.to_string()
         },
         Err(e) => {
-            println!("Error interpreting environment variable key {}: {}", key, e);
+            error!("Error interpreting environment variable key {}: {}", key, e);
             "".to_string()
         },
     }
 }
 
 pub fn set_test_env() {
-    // Set the environment variable key `TEST` to with value of "1"
+    // Set the environment variable key `TEST` to value of "1"
     // when `cargo test` has been run, otherwise set it to "0"
     let key = "RUST_ENV";
     let value_test = "TEST";

--- a/src/cli/config_env.rs
+++ b/src/cli/config_env.rs
@@ -1,7 +1,7 @@
 use std::env;
 
-pub fn get_test_env() -> String {
-    let key = "TEST";
+pub fn get_env() -> String {
+    let key = "RUST_ENV";
     match env::var(key) {
         Ok(val) => {
             println!("Found environment variable key {}: {:?}", key, val);
@@ -17,22 +17,22 @@ pub fn get_test_env() -> String {
 pub fn set_test_env() {
     // Set the environment variable key `TEST` to with value of "1"
     // when `cargo test` has been run, otherwise set it to "0"
-    let key = "TEST";
-    let enabled = "1";
-    let disabled = "0";
+    let key = "RUST_ENV";
+    let value_test = "TEST";
+    let value_development = "DEVELOPMENT";
     if let Some(arg0) = env::args().nth(0) {
         if arg0 == "target/debug/diamond_drops" {
-            env::set_var(key, disabled);
-            assert_eq!(env::var(key), Ok(disabled.to_string()));
+            env::set_var(key, value_development);
+            assert_eq!(env::var(key), Ok(value_development.to_string()));
         } else {
-            env::set_var(key, enabled);
-            assert_eq!(env::var(key), Ok(enabled.to_string()));
+            env::set_var(key, value_test);
+            assert_eq!(env::var(key), Ok(value_test.to_string()));
         }
     }
 }
 
 pub fn is_running_with_cargo_test() -> bool {
-    if get_test_env() == "1" {
+    if get_env() == "TEST" {
         true
     } else {
         false

--- a/src/cli/config_env.rs
+++ b/src/cli/config_env.rs
@@ -1,0 +1,40 @@
+use std::env;
+
+pub fn get_test_env() -> String {
+    let key = "TEST";
+    match env::var(key) {
+        Ok(val) => {
+            println!("Found environment variable key {}: {:?}", key, val);
+            val.to_string()
+        },
+        Err(e) => {
+            println!("Error interpreting environment variable key {}: {}", key, e);
+            "".to_string()
+        },
+    }
+}
+
+pub fn set_test_env() {
+    // Set the environment variable key `TEST` to with value of "1"
+    // when `cargo test` has been run, otherwise set it to "0"
+    let key = "TEST";
+    let enabled = "1";
+    let disabled = "0";
+    if let Some(arg0) = env::args().nth(0) {
+        if arg0 == "target/debug/diamond_drops" {
+            env::set_var(key, disabled);
+            assert_eq!(env::var(key), Ok(disabled.to_string()));
+        } else {
+            env::set_var(key, enabled);
+            assert_eq!(env::var(key), Ok(enabled.to_string()));
+        }
+    }
+}
+
+pub fn is_running_with_cargo_test() -> bool {
+    if get_test_env() == "1" {
+        true
+    } else {
+        false
+    }
+}

--- a/src/cli/config_log.rs
+++ b/src/cli/config_log.rs
@@ -1,10 +1,13 @@
 use fern;
+use fern::colors::{Color, ColoredLevelConfig};
 use log::{LevelFilter};
 use chrono;
 
 use std::io;
 
 fn setup_logger(verbosity: u64) -> Result<(), fern::InitError> {
+    let colors = ColoredLevelConfig::new().debug(Color::Magenta);
+
     let mut base_config = fern::Dispatch::new();
 
     base_config = match verbosity {
@@ -33,12 +36,12 @@ fn setup_logger(verbosity: u64) -> Result<(), fern::InitError> {
         .chain(fern::log_file("output.log")?);
 
     let stdout_config = fern::Dispatch::new()
-        .format(|out, message, record| {
+        .format(move |out, message, record| {
             out.finish(format_args!(
                 "{}[{}][{}] {}",
                 chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
                 record.target(),
-                record.level(),
+                colors.color(record.level()),
                 message
             ))
         })

--- a/src/cli/config_log.rs
+++ b/src/cli/config_log.rs
@@ -1,5 +1,6 @@
 use log;
 use log::{Record, Level, Metadata, SetLoggerError, LevelFilter};
+use chrono::Local;
 
 static LOGGER: DiamondDropsLogger = DiamondDropsLogger;
 
@@ -12,7 +13,7 @@ impl log::Log for DiamondDropsLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            println!("{} - {}", record.level(), record.args());
+            println!("{} [{}] - {}", Local::now().format("%Y-%m-%dT%H:%M:%S"), record.level(), record.args());
         }
     }
 

--- a/src/cli/config_log.rs
+++ b/src/cli/config_log.rs
@@ -1,6 +1,9 @@
+use fern;
 use log;
 use log::{Record, Level, Metadata, SetLoggerError, LevelFilter};
 use chrono::Local;
+
+use std::io;
 
 static LOGGER: DiamondDropsLogger = DiamondDropsLogger;
 
@@ -13,27 +16,35 @@ impl log::Log for DiamondDropsLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            println!("{} [{}] - {}", Local::now().format("%Y-%m-%dT%H:%M:%S"), record.level(), record.args());
+            println!("{} [{}] - {}", Local::now().format("[%Y-%m-%d][T%H:%M:%S]"), record.level(), record.args());
         }
     }
 
     fn flush(&self) {}
 }
 
+fn setup_logger() -> Result<(), fern::InitError> {
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{}[{}][{}] {}",
+                Local::now().format("[%Y-%m-%d][T%H:%M:%S]"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .level(log::LevelFilter::Debug)
+        .chain(io::stdout())
+        .chain(fern::log_file("output.log")?)
+        .apply()?;
+    Ok(())
+}
+
 pub fn init() -> () {
-    /*! Initialisation of [Log Crate](https://crates.io/crates/log) with choice of logging level macros */
-    /*! from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`. */
+    /*! Initialisation of [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/) */
+    /*! with choice of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`. */
     /*! [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) are configured in Cargo.toml */
 
-    let logger = log::set_logger(&LOGGER);
-    match logger {
-        Ok(res) => {
-            log::set_max_level(LevelFilter::Trace);
-            eprintln!("Success initializing Rust Logger to max level: {}", log::max_level());
-            ()
-        }
-        Err(e) => {
-            eprintln!("Error initializing Rust Logger: {}", e);
-        }
-    }
+    setup_logger();
 }

--- a/src/cli/config_log.rs
+++ b/src/cli/config_log.rs
@@ -1,0 +1,38 @@
+use log;
+use log::{Record, Level, Metadata, SetLoggerError, LevelFilter};
+
+static LOGGER: DiamondDropsLogger = DiamondDropsLogger;
+
+struct DiamondDropsLogger;
+
+impl log::Log for DiamondDropsLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Trace
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init() -> () {
+    /*! Initialisation of [Log Crate](https://crates.io/crates/log) with choice of logging level macros */
+    /*! from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`. */
+    /*! [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) are configured in Cargo.toml */
+
+    let logger = log::set_logger(&LOGGER);
+    match logger {
+        Ok(res) => {
+            log::set_max_level(LevelFilter::Trace);
+            eprintln!("Success initializing Rust Logger to max level: {}", log::max_level());
+            ()
+        }
+        Err(e) => {
+            eprintln!("Error initializing Rust Logger: {}", e);
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod config_env;
 pub mod args;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod config_env;
+pub mod config_log;
 pub mod args;

--- a/src/client_thread.rs
+++ b/src/client_thread.rs
@@ -1,20 +1,21 @@
-use std::sync::mpsc;
-use std::thread;
-
 use cli::config;
 use notary;
 use proposer;
 use message;
 
+use std::sync::mpsc;
+use std::thread;
+
 /// A request to terminate a running thread
+#[derive(Debug)]
 pub enum Command {
     Terminate
 }
 
 pub struct ClientThread {
-    pub handle: Option<thread::JoinHandle<()>>,
     mode: config::Mode,
-    pub manager: Option<mpsc::Sender<Command>>
+    pub manager: Option<mpsc::Sender<Command>>,
+    pub handle: Option<thread::JoinHandle<()>>
 }
 
 impl ClientThread {
@@ -22,19 +23,19 @@ impl ClientThread {
         match *mode {
             config::Mode::Notary => { 
                 ClientThread {
-                    handle: None,
-                    mode: mode.clone(), 
-                    manager: None
+                    mode: mode.clone(),
+                    manager: None,
+                    handle: None
                 }
             },
             config::Mode::Proposer => {
                 ClientThread {
-                    handle: None,
                     mode: mode.clone(),
-                    manager: None
+                    manager: None,
+                    handle: None
                 }
             },
-            _ => { panic!() }
+            _ => { panic!("Invalid mode provided to generate client thread instance"); }
         }
     }
 
@@ -48,7 +49,7 @@ impl ClientThread {
                 self.handle = Some(thread::Builder::new()
                                     .name(config::Mode::Notary.value())
                                     .spawn(move || {
-                                    notary.run();
+                                        notary.run();
                                     })
                                     .expect("Failed to spawn a notary thread"));
             },
@@ -64,7 +65,7 @@ impl ClientThread {
                                 })
                                 .expect("Failed to spawn a proposer thread"));
             }
-            _ => { panic!() }
+            _ => { panic!("Invalid mode provided to spawn new child thread from client thread instance") }
         }
     }
 }

--- a/src/collation/header.rs
+++ b/src/collation/header.rs
@@ -69,8 +69,9 @@ impl Header {
         ethereum_types::H256::from_slice(&result_bytes[..])
     }
 }
-/*
-// A crude way of converting the ethereum_types::U256 to a u8 byte array to be hashed.  Suggestions to improve this are desired. 
+
+// TODO - consider replacing with https://docs.rs/ethereum-types/0.3.1/ethereum_types/struct.U256.html#method.as_u32
+// A crude way of converting the ethereum_types::U256 to a u8 byte array to be hashed.  Suggestions to improve this are desired.
 fn u256_to_bytes32(u256: ethereum_types::U256) -> [u8; 32] {
     let mut bytes32: [u8; 32] = [0; 32];
     for i in 0..32 {
@@ -78,7 +79,6 @@ fn u256_to_bytes32(u256: ethereum_types::U256) -> [u8; 32] {
     }
     bytes32
 }
-*/
 
 #[cfg(test)]
 mod tests {
@@ -89,7 +89,7 @@ mod tests {
         // Build the args for collation header creation
         // Shard Id
         let shard_id = ethereum_types::U256::from_dec_str("1").unwrap();
-        let shard_id_bytes = ethereum_types::U256::as_u32(shard_id);/*u256_to_bytes32(shard_id);*/
+        let shard_id_bytes = u256_to_bytes32(shard_id);
         
         /*
         // Parent Hash
@@ -109,7 +109,7 @@ mod tests {
 
         // Period
         let period = ethereum_types::U256::from_dec_str("1").unwrap();
-        let period_bytes = ethereum_types::U256::as_u32(period)/*u256_to_bytes32(period);*/
+        let period_bytes = u256_to_bytes32(period);
 
         // Proposer Address
         let proposer_address_bytes: [u8; 20] = [0x39, 0xa4, 0x2d, 0x47, 0x4a,

--- a/src/collation/header.rs
+++ b/src/collation/header.rs
@@ -69,7 +69,7 @@ impl Header {
         ethereum_types::H256::from_slice(&result_bytes[..])
     }
 }
-
+/*
 // A crude way of converting the ethereum_types::U256 to a u8 byte array to be hashed.  Suggestions to improve this are desired. 
 fn u256_to_bytes32(u256: ethereum_types::U256) -> [u8; 32] {
     let mut bytes32: [u8; 32] = [0; 32];
@@ -78,7 +78,7 @@ fn u256_to_bytes32(u256: ethereum_types::U256) -> [u8; 32] {
     }
     bytes32
 }
-
+*/
 
 #[cfg(test)]
 mod tests {
@@ -89,14 +89,14 @@ mod tests {
         // Build the args for collation header creation
         // Shard Id
         let shard_id = ethereum_types::U256::from_dec_str("1").unwrap();
-        let shard_id_bytes = u256_to_bytes32(shard_id);
+        let shard_id_bytes = ethereum_types::U256::as_u32(shard_id);/*u256_to_bytes32(shard_id);*/
         
         /*
         // Parent Hash
         let parent_hash_bytes: [u8; 32] = [0x50, 0xa1, 0xb3, 0xd5, 0x14, 0xd4, 0x99, 0x63,
-                                  0x54, 0x14, 0x7a, 0xd2, 0x89, 0x61, 0x75, 0xb0, 
-                                  0x7d, 0x43, 0x7f, 0x9e, 0x58, 0xfa, 0x3c, 0x44, 
-                                  0x86, 0xc0, 0x42, 0xf4, 0xc3, 0xd5, 0x05, 0x9b];
+                                           0x54, 0x14, 0x7a, 0xd2, 0x89, 0x61, 0x75, 0xb0, 
+                                           0x7d, 0x43, 0x7f, 0x9e, 0x58, 0xfa, 0x3c, 0x44, 
+                                           0x86, 0xc0, 0x42, 0xf4, 0xc3, 0xd5, 0x05, 0x9b];
         let parent_hash = ethereum_types::H256::from_slice(&parent_hash_bytes[..]);
         */
 
@@ -109,13 +109,13 @@ mod tests {
 
         // Period
         let period = ethereum_types::U256::from_dec_str("1").unwrap();
-        let period_bytes = u256_to_bytes32(period);
+        let period_bytes = ethereum_types::U256::as_u32(period)/*u256_to_bytes32(period);*/
 
         // Proposer Address
         let proposer_address_bytes: [u8; 20] = [0x39, 0xa4, 0x2d, 0x47, 0x4a,
-                                        0x52, 0x96, 0xab, 0x98, 0x52, 
-                                        0x3b, 0x1a, 0x3d, 0xef, 0x8f, 
-                                        0x18, 0x67, 0xad, 0x32, 0xb0];
+                                                0x52, 0x96, 0xab, 0x98, 0x52, 
+                                                0x3b, 0x1a, 0x3d, 0xef, 0x8f, 
+                                                0x18, 0x67, 0xad, 0x32, 0xb0];
         let proposer_address = ethereum_types::H160::from_slice(&proposer_address_bytes[..]);
 
         // Create the header

--- a/src/collation/header.rs
+++ b/src/collation/header.rs
@@ -15,7 +15,7 @@ pub struct Header {
 }
 
 impl Header {
-    pub fn new(shard_id: ethereum_types::U256, 
+    pub fn new(shard_id: ethereum_types::U256,
                //parent_hash: ethereum_types::H256,
                chunk_root: ethereum_types::H256,
                period: ethereum_types::U256,
@@ -88,49 +88,49 @@ mod tests {
     fn it_produces_correct_hash() {
         // Build the args for collation header creation
         // Shard Id
-        let sid = ethereum_types::U256::from_dec_str("1").unwrap();
-        let sid_bytes = u256_to_bytes32(sid);
+        let shard_id = ethereum_types::U256::from_dec_str("1").unwrap();
+        let shard_id_bytes = u256_to_bytes32(shard_id);
         
         /*
         // Parent Hash
-        let ph_bytes: [u8; 32] = [0x50, 0xa1, 0xb3, 0xd5, 0x14, 0xd4, 0x99, 0x63, 
+        let parent_hash_bytes: [u8; 32] = [0x50, 0xa1, 0xb3, 0xd5, 0x14, 0xd4, 0x99, 0x63,
                                   0x54, 0x14, 0x7a, 0xd2, 0x89, 0x61, 0x75, 0xb0, 
                                   0x7d, 0x43, 0x7f, 0x9e, 0x58, 0xfa, 0x3c, 0x44, 
                                   0x86, 0xc0, 0x42, 0xf4, 0xc3, 0xd5, 0x05, 0x9b];
-        let ph = ethereum_types::H256::from_slice(&ph_bytes[..]);
+        let parent_hash = ethereum_types::H256::from_slice(&parent_hash_bytes[..]);
         */
-        
+
         // Chunk Root
-        let cr_bytes: [u8; 32] = [0x50, 0xce, 0xc0, 0x49, 0x54, 0x77, 0xfb, 0x7e,
-                                  0x65, 0x25, 0xc2, 0xa0, 0x39, 0xa3, 0xa9, 0x95, 
-                                  0x34, 0x90, 0x35, 0xb2, 0xa8, 0x23, 0xa4, 0x99,
-                                  0x0b, 0x27, 0xf6, 0xd7, 0xd5, 0x5e, 0xec, 0x6b];
-        let cr = ethereum_types::H256::from_slice(&cr_bytes[..]);
+        let chunk_root_bytes: [u8; 32] = [0x50, 0xce, 0xc0, 0x49, 0x54, 0x77, 0xfb, 0x7e,
+                                          0x65, 0x25, 0xc2, 0xa0, 0x39, 0xa3, 0xa9, 0x95,
+                                          0x34, 0x90, 0x35, 0xb2, 0xa8, 0x23, 0xa4, 0x99,
+                                          0x0b, 0x27, 0xf6, 0xd7, 0xd5, 0x5e, 0xec, 0x6b];
+        let chunk_root = ethereum_types::H256::from_slice(&chunk_root_bytes[..]);
 
         // Period
         let period = ethereum_types::U256::from_dec_str("1").unwrap();
         let period_bytes = u256_to_bytes32(period);
 
         // Proposer Address
-        let proposer_bytes: [u8; 20] = [0x39, 0xa4, 0x2d, 0x47, 0x4a,
+        let proposer_address_bytes: [u8; 20] = [0x39, 0xa4, 0x2d, 0x47, 0x4a,
                                         0x52, 0x96, 0xab, 0x98, 0x52, 
                                         0x3b, 0x1a, 0x3d, 0xef, 0x8f, 
                                         0x18, 0x67, 0xad, 0x32, 0xb0];
-        let proposer = ethereum_types::H160::from_slice(&proposer_bytes[..]);
+        let proposer_address = ethereum_types::H160::from_slice(&proposer_address_bytes[..]);
 
         // Create the header
-        let header = Header::new(sid, /*ph,*/ cr, period, proposer);
+        let header = Header::new(shard_id, /*parent_hash,*/ chunk_root, period, proposer_address);
 
         // Calculate its generated hash
         let header_hash = header.hash();
 
         // Calculate the expected hash
         let mut sha3 = tiny_keccak::Keccak::new_sha3_256();
-        sha3.update(&sid_bytes[..]);
-        //sha3.update(&ph_bytes[..]);
-        sha3.update(&cr_bytes[..]);
+        sha3.update(&shard_id_bytes[..]);
+        //sha3.update(&parent_hash_bytes[..]);
+        sha3.update(&chunk_root_bytes[..]);
         sha3.update(&period_bytes[..]);
-        sha3.update(&proposer_bytes[..]);
+        sha3.update(&proposer_address_bytes[..]);
 
         let mut expected_bytes: [u8; 32] = [0; 32];
         sha3.finalize(&mut expected_bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 // External crates
 extern crate ethereum_types;
 extern crate tiny_keccak;
+
+extern crate fern;
 #[macro_use]
 extern crate log;
 extern crate chrono;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate ethereum_types;
 extern crate tiny_keccak;
 #[macro_use]
 extern crate log;
+extern crate chrono;
 
 // Module declarations
 pub mod cli;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 // External crates
 extern crate ethereum_types;
 extern crate tiny_keccak;
+#[macro_use]
+extern crate log;
 
 // Module declarations
 pub mod cli;
@@ -24,11 +26,11 @@ use std::sync::mpsc;
 /// 
 /// config - A struct containing the configuration values for the client
 pub fn run(config: cli::config::Config) -> () {
-    println!("Client Mode: {:?}", config.mode);
+    debug!("Client Mode: {:?}", config.mode);
 
     match config.mode {
         cli::config::Mode::Proposer => {
-            println!("Running as a proposer");
+            debug!("Running as a proposer");
 
             // Create the SMC Listener
             let (smc_tx, smc_rx) = mpsc::channel();
@@ -45,12 +47,12 @@ pub fn run(config: cli::config::Config) -> () {
 
             // Wait for thread termination
             match proposer_thread.handle.unwrap().join() {
-                Ok(x) => { println!("Successful proposer thread join {:?}", x); () },
+                Ok(x) => { debug!("Successful proposer thread join {:?}", x); () },
                 Err(e) => { panic!("Failed proposer thread join {:?}", e); }
             }
         },
         cli::config::Mode::Notary => {
-            println!("Running as a notary");
+            debug!("Running as a notary");
 
             // Create the SMC Listener
             let (smc_tx, smc_rx) = mpsc::channel();
@@ -67,12 +69,12 @@ pub fn run(config: cli::config::Config) -> () {
 
             // Wait for thread termination
             match notary_thread.handle.unwrap().join() {
-                Ok(x) => { println!("Successful notary thread join {:?}", x); () },
+                Ok(x) => { debug!("Successful notary thread join {:?}", x); () },
                 Err(e) => { panic!("Failed notary thread join {:?}", e); }
             }
         },
         cli::config::Mode::Both => {
-            println!("Running as both a proposer and notary");
+            debug!("Running as both a proposer and notary");
 
             // Create the SMC Listeners
             let (notary_smc_tx, notary_smc_rx) = mpsc::channel();
@@ -95,11 +97,11 @@ pub fn run(config: cli::config::Config) -> () {
 
             // Wait for thread termination
             match proposer_thread.handle.unwrap().join() {
-                Ok(x) => { println!("Successful proposer thread join {:?}", x); () },
+                Ok(x) => { debug!("Successful proposer thread join {:?}", x); () },
                 Err(e) => { panic!("Failed proposer thread join {:?}", e); }
             }
             match notary_thread.handle.unwrap().join() {
-                Ok(x) => { println!("Successful notary thread join {:?}", x); () },
+                Ok(x) => { debug!("Successful notary thread join {:?}", x); () },
                 Err(e) => { panic!("Failed notary thread join {:?}", e); }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,10 @@ pub fn run(config: cli::config::Config) -> () {
             let mut proposer_thread = client_thread::ClientThread::new(&config.mode);
             proposer_thread.run(smc_rx);
 
-            // TODO make this part only run when running 'cargo test'
-            thread::sleep(Duration::from_secs(1));
-            let _result = proposer_thread.manager.unwrap().send(client_thread::Command::Terminate);
+            if cli::config_env::is_running_with_cargo_test() {
+                thread::sleep(Duration::from_secs(1));
+                let _result = proposer_thread.manager.unwrap().send(client_thread::Command::Terminate);
+            }
 
             // Wait for thread termination
             match proposer_thread.handle.unwrap().join() {
@@ -59,9 +60,10 @@ pub fn run(config: cli::config::Config) -> () {
             let mut notary_thread = client_thread::ClientThread::new(&config.mode);
             notary_thread.run(smc_rx);
 
-            // TODO make this part only run when running 'cargo test'
-            thread::sleep(Duration::from_secs(1));
-            let _result = notary_thread.manager.unwrap().send(client_thread::Command::Terminate);
+            if cli::config_env::is_running_with_cargo_test() {
+                thread::sleep(Duration::from_secs(1));
+                let _result = notary_thread.manager.unwrap().send(client_thread::Command::Terminate);
+            }
 
             // Wait for thread termination
             match notary_thread.handle.unwrap().join() {
@@ -85,10 +87,11 @@ pub fn run(config: cli::config::Config) -> () {
             proposer_thread.run(proposer_smc_rx);
             notary_thread.run(notary_smc_rx);
 
-            // TODO make this part only run when running 'cargo test'
-            thread::sleep(Duration::from_secs(1));
-            let _p_result = proposer_thread.manager.unwrap().send(client_thread::Command::Terminate);
-            let _n_result = notary_thread.manager.unwrap().send(client_thread::Command::Terminate);
+            if cli::config_env::is_running_with_cargo_test() {
+                thread::sleep(Duration::from_secs(1));
+                let _p_result = proposer_thread.manager.unwrap().send(client_thread::Command::Terminate);
+                let _n_result = notary_thread.manager.unwrap().send(client_thread::Command::Terminate);
+            }
 
             // Wait for thread termination
             match proposer_thread.handle.unwrap().join() {
@@ -102,5 +105,4 @@ pub fn run(config: cli::config::Config) -> () {
         }
     }
 }
-
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate diamond_drops;
+
 use diamond_drops::cli;
 use diamond_drops::cli::{args};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate diamond_drops;
 
+extern crate fern;
 #[macro_use]
 extern crate log;
 extern crate chrono;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 extern crate diamond_drops;
 
+#[macro_use]
+extern crate log;
+
 use diamond_drops::cli;
 use diamond_drops::cli::{args};
 
@@ -9,10 +12,11 @@ use std::process;
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
 
+    cli::config_log::init();
     cli::config_env::set_test_env();
 
     let config = cli::args::parse_cli_args(args).unwrap_or_else(|err| {
-        eprintln!("Problem parsing arguments: {}", err);
+        error!("Problem parsing arguments: {}", err);
         process::exit(1);
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate diamond_drops;
 use diamond_drops::cli;
+use diamond_drops::cli::{args};
 
 use std::env;
 use std::process;
@@ -7,10 +8,47 @@ use std::process;
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
 
+    cli::config_env::set_test_env();
+
     let config = cli::args::parse_cli_args(args).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {}", err);
         process::exit(1);
     });
 
     diamond_drops::run(config);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_does_not_panic_running_client_mode_with_proposer() {
+        cli::config_env::set_test_env();
+        let test_args_short = vec![String::from("-mode"), String::from("p")];
+        let config_short = cli::args::parse_cli_args(test_args_short).unwrap();
+        let result = diamond_drops::run(config_short);
+
+        assert_eq!(result, ());
+    }
+
+    #[test]
+    fn it_does_not_panic_running_client_mode_with_notary() {
+        cli::config_env::set_test_env();
+        let test_args_short = vec![String::from("-mode"), String::from("n")];
+        let config_short = cli::args::parse_cli_args(test_args_short).unwrap();
+        let result = diamond_drops::run(config_short);
+
+        assert_eq!(result, ());
+    }
+
+    #[test]
+    fn it_does_not_panic_running_client_mode_with_both() {
+        cli::config_env::set_test_env();
+        let test_args_short = vec![String::from("-mode"), String::from("b")];
+        let config_short = cli::args::parse_cli_args(test_args_short).unwrap();
+        let result = diamond_drops::run(config_short);
+
+        assert_eq!(result, ());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate diamond_drops;
 
 #[macro_use]
 extern crate log;
+extern crate chrono;
 
 use diamond_drops::cli;
 use diamond_drops::cli::{args};

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,6 +2,7 @@ use collation::collation;
 
 use ethereum_types;
 
+#[derive(Debug)]
 pub enum Message {
     Selected{value: bool},
     ShardId{value: ethereum_types::U256},

--- a/src/notary.rs
+++ b/src/notary.rs
@@ -48,13 +48,13 @@ impl Notary {
             // Respond to the thread manager message
             match manager_msg {
                 Some(msg) => {
-                    println!("Received pending message {:?} in thread {:?} from another thread", msg, thread::current());
+                    debug!("Received pending message {:?} in thread {:?} from another thread", msg, thread::current());
                     match msg {
                         client_thread::Command::Terminate => { break }
                     }
                 },
                 None => {
-                    // println!("No more pending messages from other threads to thread {:?} or channel hung up", thread::current());
+                     trace!("No more pending messages from other threads to thread {:?} or channel hung up", thread::current());
                 }
             }
 
@@ -64,7 +64,7 @@ impl Notary {
             // Respond to SMC listener message
             match smc_msg {
                 Some(msg) => {
-                    println!("Received pending message {:?} in thread {:?} from SMC Listener", msg, thread::current());
+                    debug!("Received pending message {:?} in thread {:?} from SMC Listener", msg, thread::current());
                     match msg {
                         message::Message::Selected { value } => { self.selected = value; }
                         message::Message::ShardId { value } => { self.shard_id = value; },
@@ -73,7 +73,7 @@ impl Notary {
                     }
                 },
                 None => {
-                    // println!("No more pending messages from SMC Listener to thread {:?} or channel hung", thread::current());
+                     trace!("No more pending messages from SMC Listener to thread {:?} or channel hung", thread::current());
                 }
             }
 
@@ -85,14 +85,14 @@ impl Notary {
     }
 
     fn store_collation(&mut self, collation: collation::Collation) {
-        println!("Storing in notary id {} a new collation mapped to shard id {}", self.id, self.shard_id);
+        debug!("Storing in notary id {} a new collation mapped to shard id {}", self.id, self.shard_id);
         self.collation_vectors.entry(self.shard_id).or_insert(vec![]);
         let vector = self.collation_vectors.get_mut(&self.shard_id).unwrap();
         vector.push(collation);
     }
 
     fn store_proposal(&mut self, proposal: collation::Collation) {
-        println!("Storing in notary id {} a new proposal collation mapped to shard id {}", self.id, self.shard_id);
+        debug!("Storing in notary id {} a new proposal collation mapped to shard id {}", self.id, self.shard_id);
         self.proposal_vectors.entry(self.shard_id).or_insert(vec![]);
         let vector = self.proposal_vectors.get_mut(&self.shard_id).unwrap();
         vector.push(proposal);

--- a/src/proposer.rs
+++ b/src/proposer.rs
@@ -1,8 +1,14 @@
-pub struct Proposer;
+use ethereum_types;
+
+pub struct Proposer {
+    id: ethereum_types::U256
+}
 
 impl Proposer {
     pub fn new() -> Proposer {
-        Proposer
+        Proposer {
+            id: ethereum_types::U256::from_dec_str("0").unwrap()
+        }
     }
 
     pub fn run(&self) {}

--- a/src/smc_listener.rs
+++ b/src/smc_listener.rs
@@ -22,8 +22,8 @@ impl SMCListener {
         let result: Result<String, String> = Result::Err(String::from("Error"));
 
         match result {
-            Ok(msg) => { println!("Success registered notary address {:?} with SMC Contract", notary_addr); true },
-            Err(e) => { println!("Error registering notary address {:?} with SMC Contract: {:?}", notary_addr, e); false }
+            Ok(msg) => { info!("Success registered notary address {:?} with SMC Contract", notary_addr); true },
+            Err(e) => { error!("Error registering notary address {:?} with SMC Contract: {:?}", notary_addr, e); false }
         }
     }
 
@@ -36,8 +36,8 @@ impl SMCListener {
         let result: Result<String, String> = Result::Err(String::from("Error"));
 
         match result {
-            Ok(msg) => { println!("Success registered proposer address {:?} with SMC Contract", proposer_addr); true },
-            Err(e) => { println!("Error registering proposer address {:?} with SMC Contract: {:?}", proposer_addr, e); false }
+            Ok(msg) => { info!("Success registered proposer address {:?} with SMC Contract", proposer_addr); true },
+            Err(e) => { error!("Error registering proposer address {:?} with SMC Contract: {:?}", proposer_addr, e); false }
         }
     }
 }

--- a/src/smc_listener.rs
+++ b/src/smc_listener.rs
@@ -1,6 +1,8 @@
-use ethereum_types;
-use std::sync::mpsc;
 use message;
+
+use ethereum_types;
+
+use std::sync::mpsc;
 
 pub struct SMCListener {
     period: ethereum_types::U256,
@@ -15,12 +17,28 @@ impl SMCListener {
         }
     }
 
-    fn register(&self, addr: ethereum_types::Address) -> Result<bool, &'static str> {
-        Ok(false)
+    fn register_notary_address(&self, notary_addr: ethereum_types::Address) -> bool {
+        // TODO - Implement registration of notary address in notary registry of SMC Contract
+        let result: Result<String, String> = Result::Err(String::from("Error"));
+
+        match result {
+            Ok(msg) => { println!("Success registered notary address {:?} with SMC Contract", notary_addr); true },
+            Err(e) => { println!("Error registering notary address {:?} with SMC Contract: {:?}", notary_addr, e); false }
+        }
     }
 
-    fn get_selected_notaries(&self, shard_id: usize) -> Vec<ethereum_types::Address> {
+    fn get_selected_notaries(&self, shard_id: ethereum_types::U256) -> Vec<ethereum_types::Address> {
         vec![ethereum_types::Address::zero()]
+    }
+
+    fn register_proposer_address(&self, proposer_addr: ethereum_types::Address) -> bool {
+        // TODO - Implement registration of proposer address in proposer registry of SMC Contract
+        let result: Result<String, String> = Result::Err(String::from("Error"));
+
+        match result {
+            Ok(msg) => { println!("Success registered proposer address {:?} with SMC Contract", proposer_addr); true },
+            Err(e) => { println!("Error registering proposer address {:?} with SMC Contract: {:?}", proposer_addr, e); false }
+        }
     }
 }
 
@@ -30,12 +48,23 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn it_registers() {
+    fn it_registered_notary_address_in_notary_registry_of_smc_contract() {
         let (tx, rx) = mpsc::channel();
         let smc = SMCListener::new(tx);
-        let addr_bytes: [u8; 20] = [0x22, 0xFF, 0x31, 0x10, 0xA2, 0x82, 0xc1, 0x19, 0x77, 0x36, 0xb3, 0xfC, 0xe3, 0x4a, 0xD4, 0xFc, 0x5e, 0xEe, 0x75, 0xc8];
-        let addr: ethereum_types::Address = ethereum_types::Address::from_slice(&addr_bytes);
-        let result = smc.register(addr).unwrap();
+        let notary_addr_bytes: [u8; 20] = [0x22, 0xFF, 0x31, 0x10, 0xA2, 0x82, 0xc1, 0x19, 0x77, 0x36, 0xb3, 0xfC, 0xe3, 0x4a, 0xD4, 0xFc, 0x5e, 0xEe, 0x75, 0xc8];
+        let notary_addr: ethereum_types::Address = ethereum_types::Address::from_slice(&notary_addr_bytes);
+        let result = smc.register_notary_address(notary_addr);
+        assert_eq!(true, result);
+    }
+
+    #[test]
+    #[ignore]
+    fn it_registered_proposer_address_in_proposer_registry_of_smc_contract() {
+        let (tx, rx) = mpsc::channel();
+        let smc = SMCListener::new(tx);
+        let proposer_addr_bytes: [u8; 20] = [0x22, 0xFF, 0x31, 0x10, 0xA2, 0x82, 0xc1, 0x19, 0x77, 0x36, 0xb3, 0xfC, 0xe3, 0x4a, 0xD4, 0xFc, 0x5e, 0xEe, 0x75, 0xc8];
+        let proposer_addr: ethereum_types::Address = ethereum_types::Address::from_slice(&proposer_addr_bytes);
+        let result = smc.register_proposer_address(proposer_addr);
         assert_eq!(true, result);
     }
 
@@ -44,14 +73,14 @@ mod tests {
     fn it_gets_selected_notaries() {
         let (tx, rx) = mpsc::channel();
         let smc = SMCListener::new(tx);
-        let shard_id = 0;
-        let addr = smc.get_selected_notaries(shard_id);
+        let shard_id = ethereum_types::U256::from_dec_str("0").unwrap();
+        let notary_addr = smc.get_selected_notaries(shard_id);
 
         // The dummy "selected notary"
-        let addr_bytes: [u8; 20] = [0x6C, 0xaC, 0xE0, 0x52, 0x83, 0x24, 0xA8, 0xaf, 0xC2, 0xb1, 0x57, 0xCe, 0xbA, 0x3c, 0xDd, 0x2a, 0x27, 0xc4, 0xE2, 0x1f];
-        let selected_addr = ethereum_types::Address::from_slice(&addr_bytes);
+        let notary_addr_bytes: [u8; 20] = [0x6C, 0xaC, 0xE0, 0x52, 0x83, 0x24, 0xA8, 0xaf, 0xC2, 0xb1, 0x57, 0xCe, 0xbA, 0x3c, 0xDd, 0x2a, 0x27, 0xc4, 0xE2, 0x1f];
+        let selected_notary_addr = ethereum_types::Address::from_slice(&notary_addr_bytes);
 
-        assert_eq!(vec![selected_addr], addr);
+        assert_eq!(vec![selected_notary_addr], notary_addr);
     }
 
     #[test]


### PR DESCRIPTION
* Changes in Commit #97f182a:
  * Restored Unit Tests that detects whether all threads finish and that it returns `()` from call to `diamond_drops::run(config)` for all CLI modes
  * Added setter and getter of a TEST environment variable so we can detect when the user is running `cargo test` and only run certain snippets of the implementation that terminates threads so the tests pass, but does not terminate the threads when TEST is disabled. This saves us having to explicitly set environment variables at the command line
  * All tests passing, including 3x additional tests that verify that this functionality works. If you remove `cli::config_env::set_test_env();` from the Unit Tests that are included in main.rs then the tests will not pass

* Changes in Commit #c7cba5d:
  * Change environment variables to `RUST_ENV: TEST` or `RUST_ENV: DEVELOP` for consistency

* Changes in Commit #f8cad45:
  * Rearranged order of imported files, and struct attributes for consistency
  * Add `#[derive(Debug)]` to enums to allow use with `println!` with `{:?}`
  * Add meaningful message to `panic!` calls
  * Fix indentation of `notary.run();`
  * Change variable names used in collation/header.rs tests to be more readable and consistent with implementation
  * Add `id` attribute to `Notary` and `Proposer` structs for identification when debugging the client, such as knowing what notary id we are storing a collation into
  * Add `println!` for debugging received messages and current thread in SMC listener
  * Add `generate_notary()` function to remove code duplication in notary tests
  * Update SMC registration function to be notary or proposer specific, and to return primative boolean value with meaningful success or error logs
  * Change `get_selected_notaries()` function to accept `shard_id` argument of `ethereum_types::U256` instead of `usize` for consistency withe the rest of the code
  * Add `register_proposer_address()` since there will be both a notary registry and a proposer registry in the SMC Contract according to the Phase 1 Sharding spec
  * Change notary test function names to be more explicit