### PR TITLE
feat: Fixes #39. Integrates Clap CLI with Help menu. Update all tests passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ doc = false # Resolve documentation conflict
 diamond-drops-cli = { path = "cli" }
 diamond-drops-env = { path = "env" }
 diamond-drops-node = { path = "node" }
+clap = { version = "2.31.2", features = [] } # only for integration tests
 log = { version = "0.4.1", features = ["max_level_debug", "release_max_level_warn"] }
 
 [dev-dependencies]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -53,10 +53,10 @@ script = ["cargo watch --watch . --clear --debug -s=\"cargo make test-all-watch\
 script = ["cargo run -- -l 4 mode -p"]
 
 [tasks.run-notary]
-script = ["cargo run -- -l 4 mode n"]
+script = ["cargo run -- -l 4 mode -n"]
 
 [tasks.run-both]
-script = ["cargo run -- -l 4 mode b"]
+script = ["cargo run -- -l 4 mode -b"]
 
 [tasks.p]
 alias = "run-proposer"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,7 +99,18 @@ command = "cargo"
 args = ["doc", "--open"]
 dependencies = ["build"]
 
-[tasks.uml]
+# Show list of applications installed `ls /Applications`
+[tasks.uml-chrome]
 command = "open"
 args = ["-a", "Google Chrome", "./diagrams/ml.svg"]
+dependencies = ["build"]
+
+[tasks.uml-firefox]
+command = "open"
+args = ["-a", "Firefox", "./diagrams/ml.svg"]
+dependencies = ["build"]
+
+[tasks.uml-brave]
+command = "open"
+args = ["-a", "Brave", "./diagrams/ml.svg"]
 dependencies = ["build"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -50,13 +50,13 @@ script = [
 script = ["cargo watch --watch . --clear --debug -s=\"cargo make test-all-watch\""]
 
 [tasks.run-proposer]
-script = ["cargo run -- -mode p"]
+script = ["cargo run -- -l 4 mode -p"]
 
 [tasks.run-notary]
-script = ["cargo run -- -mode n"]
+script = ["cargo run -- -l 4 mode n"]
 
 [tasks.run-both]
-script = ["cargo run -- -mode b"]
+script = ["cargo run -- -l 4 mode b"]
 
 [tasks.p]
 alias = "run-proposer"
@@ -70,9 +70,9 @@ alias = "run-both"
 [tasks.run-all]
 script = [
     "echo \"Running all modes\"",
-    "cargo run -- -mode p",          # Proposer Mode Only
-    "cargo run -- -mode n",          # Notary Mode Only
-    "cargo run -- -mode b"           # Both Proposer and Notary Modes
+    "cargo run -- -l 4 mode -p",          # Proposer Mode Only
+    "cargo run -- -l 4 mode -n",          # Notary Mode Only
+    "cargo run -- -l 4 mode -b"           # Both Proposer and Notary Modes
 ]
 dependencies = ["clean"]
 
@@ -82,9 +82,9 @@ alias = "run-all"
 [tasks.run-all-with-bin]
 script = [
     "echo \"Running all modes\"",
-    "cargo run --bin cli -- -mode p", # Proposer Mode Only
-    "cargo run --bin cli -- -mode n", # Notary Mode Only
-    "cargo run --bin cli -- -mode b"  # Both Proposer and Notary Modes
+    "cargo run --bin cli -- -l 4 mode -p", # Proposer Mode Only
+    "cargo run --bin cli -- -l 4 mode -n", # Notary Mode Only
+    "cargo run --bin cli -- -l 4 mode -b"  # Both Proposer and Notary Modes
 ]
 dependencies = ["clean"]
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,18 @@ See this wiki article [here](https://github.com/Drops-of-Diamond/diamond_drops/w
 
 ### View UML Diagram
 
-```bash
-cargo make uml
-```
+* View UML with Google Chrome, Mozilla Firefox, or Brave browser
+
+    ```bash
+    cargo make uml-chrome;
+    cargo make uml-firefox;
+    cargo make uml-brave;
+    ```
+
+* Custom 
+  * Choose an application on your computer to open the SVG (i.e. `ls /Applications`)
+  * Run `open -a "<APPLICATION>" "./diagrams/ml.svg"`
+  * Optionally create a Pull Request to update Makefile.toml
 
 ![](
 https://raw.githubusercontent.com/ltfschoen/Diamond-drops/develop/diagrams/ml.svg?sanitize=true)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ See [here](https://github.com/Drops-of-Diamond/diamond_drops/wiki/Introduction-a
 
 ### Setup guide
 
+#### Show help menus
+
+* Command help
+```
+cargo run -- --help
+```
+
+* Sub-command "mode" help
+```bash
+cargo run -- mode --help
+```
+
 #### Install dependencies
 
   * [Install Rust](https://github.com/rust-lang/book/blob/master/2018-edition/src/ch01-01-installation.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["James Ray (@jamesray1)", "Josiah (@ChosunOne)", "Luke Schoen (@ltfsc
 license = "Unlicense"
 
 [dependencies]
+clap = { version = "2.31.2", features = ["yaml", "debug"] } # https://clap.rs/
+env_logger = "0.5.8"
 log = { version = "0.4.1", features = ["max_level_debug", "release_max_level_warn"] }
 chrono = { version = "0.4", features = ["serde"] }
 fern = { version = "0.5", features = ["colored"] }

--- a/cli/cli.yml
+++ b/cli/cli.yml
@@ -1,0 +1,28 @@
+name: diamond-drops-cli
+version: "0.1.0-a"
+author: "James Ray (@jamesray1), Josiah (@ChosunOne), Luke Schoen (@ltfschoen)"
+about: Implementation of Ethereum Sharding in Rust
+args:
+  - log:
+      short: l
+      long: log
+      value_name: LOG
+      help: Set logging verbosity to error 0, warn 1, debug 2, info 3, or trace 4
+      required: false
+      takes_value: true
+subcommands:
+  - mode:
+      about: Choose mode(s) to run the sharding node
+      args:
+        - proposer:
+            short: p
+            long: proposer
+            help: proposer mode
+        - notary:
+            short: n
+            long: notary
+            help: notary mode
+        - both:
+            short: b
+            long: both
+            help: both proposer and notary modes

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,6 @@
+extern crate env_logger;
+#[macro_use]
+extern crate clap;
 extern crate fern;
 #[macro_use]
 extern crate log;

--- a/cli/src/modules/args.rs
+++ b/cli/src/modules/args.rs
@@ -1,6 +1,7 @@
-use modules::{config};
+use modules::{config, log};
 
-use std::process;
+use clap;
+use clap::{App, Arg, SubCommand};
 
 #[derive(PartialEq)]
 enum ConfigType {
@@ -8,54 +9,69 @@ enum ConfigType {
     Nil
 }
 
-/// Parse arguments from the command line and produce a configuration from them.
-pub fn parse_cli_args(args: Vec<String>) -> Result<config::Config, String> {
+/// Separate function to test functionality of matching CLI args of mode independent of logger
+pub fn process_mode_matches(matches: &clap::ArgMatches) -> Result<config::Config, String> {
     let mut config_type = ConfigType::Nil;
 
     // Default Case
     let mut mode = config::Mode::Both;
 
-    for arg in args {
-        // Match `-` prefixed args to a list of valid configuration points and set their
-        // values with the following non `-` prefixed value
-        if arg.starts_with("-") {
-            match arg.to_lowercase().as_ref() {
-                "-mode" => { config_type = ConfigType::Mode; },
-                _ => {
-                    let error_msg = msg_with_args("Invalid modules argument");
-                    return Err(error_msg);
-                }
+    // Handle subcommand info by conditionally getting the value and requesting matches by name
+    match matches.subcommand() {
+        ("mode", Some(subcommand_matches)) => {
+            info!("Detected mode config...");
+            if subcommand_matches.is_present("proposer") || matches.is_present("p") {
+                info!("Proposer mode activated...");
+                mode = config::Mode::Proposer;
+            } else if subcommand_matches.is_present("notary") || matches.is_present("n") {
+                info!("Notary mode activated...");
+                mode = config::Mode::Notary;
+            } else if subcommand_matches.is_present("both") || matches.is_present("b") {
+                info!("Both Proposer and Notary modes activated...");
+                mode = config::Mode::Both;
+            } else {
+                let error_msg = msg_with_args("Invalid mode argument provided");
+                return Err(error_msg);
             }
-        } else if config_type == ConfigType::Mode {
-            // Match provided value to mode type
-            match arg.to_lowercase().as_ref() {
-                "proposer" | "p" => { mode = config::Mode::Proposer; },
-                "notary" | "n" => { mode = config::Mode::Notary; },
-                "both" | "b" => { mode = config::Mode::Both; },
-                _ => {
-                    let error_msg = msg_with_args("Invalid modules value");
-                    return Err(error_msg);
-                }
-            }
-
-            config_type = ConfigType::Nil;
-        } else {
-            let error_msg = msg_with_args("No modules arguments supplied");
+            config_type = ConfigType::Mode;
+        },
+        _ => {
+            let error_msg = msg_with_args("No mode argument provided");
             return Err(error_msg);
         }
     }
 
-    if config_type == ConfigType::Nil {
+    if config_type == ConfigType::Mode {
         Ok(config::Config::new(mode))
     } else {
-        let error_msg = msg_with_args("No modules value supplied");
+        let error_msg = msg_with_args("Invalid mode argument provided");
         return Err(error_msg);
     }
 }
 
+/// Separate function to test functionality of matching CLI args of logger independent of mode
+fn process_log_matches(matches: &clap::ArgMatches) -> () {
+    let default_trace_log_level: &str = &String::from("4");
+    let log_pattern = matches.value_of("log").unwrap_or(default_trace_log_level);
+    info!("Config log pattern: {}", log_pattern);
+    log::init_logger(&log_pattern);
+    ()
+}
+
+/// Parse arguments from the command line and produce a configuration from them.
+pub fn parse_cli_args(args: Vec<String>) -> Result<config::Config, String> {
+    let yaml = load_yaml!("../../cli.yml");
+    let matches = clap::App::from_yaml(yaml).get_matches();
+
+    process_log_matches(&matches);
+
+    let mode = process_mode_matches(&matches).unwrap();
+
+    return Ok(mode);
+}
+
 fn msg_with_args(msg: &str) -> String {
-    let avail_args: &str = ", try cargo run -- -mode <argument>, \
-                            where argument is proposer, p, notary, n, both, or b.";
+    let avail_args: &str = ", try cargo run -- mode --help";
     let mut ret = msg.to_string().to_owned();
     ret.push_str(avail_args);
     ret
@@ -67,12 +83,31 @@ mod tests {
 
     #[test]
     fn it_sets_client_mode_to_proposer() {
+        let matches_long = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("proposer")
+                    .long("proposer")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "--proposer"
+            ]);
+
+        let matches_short = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("proposer")
+                    .short("p")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "-p"
+            ]);
+
         // Verbose command
-        let test_args_verbose = vec![String::from("-mode"), String::from("proposer")];
-        let config_verbose = parse_cli_args(test_args_verbose).unwrap();
+        let test_args_verbose = matches_long;
+        let config_verbose = process_mode_matches(&test_args_verbose).unwrap();
+
         // Short command
-        let test_args_short = vec![String::from("-mode"), String::from("p")];
-        let config_short = parse_cli_args(test_args_short).unwrap();
+        let test_args_short = matches_short;
+        let config_short = process_mode_matches(&test_args_short).unwrap();
 
         assert_eq!(config_verbose.mode, config::Mode::Proposer);
         assert_eq!(config_short.mode, config::Mode::Proposer);
@@ -80,12 +115,31 @@ mod tests {
 
     #[test]
     fn it_sets_client_mode_to_notary() {
+        let matches_long = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("notary")
+                    .long("notary")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "--notary"
+            ]);
+
+        let matches_short = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("notary")
+                    .short("n")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "-n"
+            ]);
+
         // Verbose command
-        let test_args_verbose = vec![String::from("-mode"), String::from("notary")];
-        let config_verbose = parse_cli_args(test_args_verbose).unwrap();
+        let test_args_verbose = matches_long;
+        let config_verbose = process_mode_matches(&test_args_verbose).unwrap();
+
         // Short command
-        let test_args_short = vec![String::from("-mode"), String::from("n")];
-        let config_short = parse_cli_args(test_args_short).unwrap();
+        let test_args_short = matches_short;
+        let config_short = process_mode_matches(&test_args_short).unwrap();
 
         assert_eq!(config_verbose.mode, config::Mode::Notary);
         assert_eq!(config_short.mode, config::Mode::Notary);
@@ -93,57 +147,111 @@ mod tests {
 
     #[test]
     fn it_sets_client_mode_to_both() {
+        let matches_long = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("both")
+                    .long("both")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "--both"
+            ]);
+
+        let matches_short = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("both")
+                    .short("b")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "-b"
+            ]);
+
         // Verbose command
-        let test_args_verbose = vec![String::from("-mode"), String::from("both")];
-        let config_verbose = parse_cli_args(test_args_verbose).unwrap();
+        let test_args_verbose = matches_long;
+        let config_verbose = process_mode_matches(&test_args_verbose).unwrap();
+
         // Short command
-        let test_args_short = vec![String::from("-mode"), String::from("b")];
-        let config_short = parse_cli_args(test_args_short).unwrap();
-        // Default mode
-        let test_args_default = vec![];
-        let config_default = parse_cli_args(test_args_default).unwrap();
+        let test_args_short = matches_short;
+        let config_short = process_mode_matches(&test_args_short).unwrap();
 
         assert_eq!(config_verbose.mode, config::Mode::Both);
         assert_eq!(config_short.mode, config::Mode::Both);
-        assert_eq!(config_default.mode, config::Mode::Both);
+    }
+
+    #[test]
+    fn it_sets_logger_with_verbose_argument() {
+        let matches_long = App::new("diamond-drops-cli")
+            .arg(Arg::with_name("log")
+                .long("log")
+                .required(false)
+                .takes_value(true))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "--log", "4"
+            ]);
+
+        // Verbose command
+        let test_args_verbose = matches_long;
+        let config_verbose = process_log_matches(&test_args_verbose);
+
+        assert_eq!(config_verbose, ());
+    }
+
+    #[test]
+    fn it_sets_logger_without_short_argument() {
+        let matches_short = App::new("diamond-drops-cli")
+            .arg(Arg::with_name("log")
+                .short("l")
+                .required(false)
+                .takes_value(true))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "-l", "4"
+            ]);
+
+        // Short command
+        let test_args_short = matches_short;
+        let config_short = process_log_matches(&test_args_short);
+
+        assert_eq!(config_short, ());
     }
 
     #[test]
     fn it_reports_invalid_arguments() {
-        // Invalid configuration
-        let test_args_configuration = vec![String::from("-bin"), String::from("notary")];
-        let error_configuration = parse_cli_args(test_args_configuration);
+        let mut error_msg = "".to_string();
 
-        // Invalid value
-        let test_args_value = vec![String::from("-mode"), String::from("bin")];
-        let error_value = parse_cli_args(test_args_value);
+        // Missing subcommand
+        let matches_invalid_subcommand = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("notary")
+                    .long("notary")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli"
+            ]);
+        let test_args_configuration = matches_invalid_subcommand;
+        let error_configuration = process_mode_matches(&test_args_configuration);
+        error_msg = msg_with_args("No mode argument provided");
 
-        // No configuration
-        let test_args_no_arg = vec![String::from("mode"), String::from("both")];
-        let error_no_arg = parse_cli_args(test_args_no_arg);
-
-        // No value
-        let test_args_no_value = vec![String::from("-mode")];
-        let error_no_value = parse_cli_args(test_args_no_value);
-
-        let mut error_msg = msg_with_args("Invalid modules argument");
         assert_eq!(error_configuration, Err(error_msg));
 
-        error_msg = msg_with_args("Invalid modules value");
-        assert_eq!(error_value, Err(error_msg));
+        // No mode argument
+        let matches_invalid_subcommand = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("notary")
+                    .long("notary")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode"
+            ]);
+        let test_args_no_arg = matches_invalid_subcommand;
+        let error_no_arg = process_mode_matches(&test_args_no_arg);
+        error_msg = msg_with_args("Invalid mode argument provided");
 
-        error_msg = msg_with_args("No modules arguments supplied");
         assert_eq!(error_no_arg, Err(error_msg));
-
-        error_msg = msg_with_args("No modules value supplied");
-        assert_eq!(error_no_value, Err(error_msg));
     }
 
     #[test]
     fn it_appends_available_arguments_postfix_to_error_message_prefix() {
         // Expected
-        let expected_output: &str = "Invalid something or other, try cargo run -- -mode <argument>, \
-                            where argument is proposer, p, notary, n, both, or b.";
+        let expected_output: &str = "Invalid something or other, try cargo run -- mode --help";
         let expected_error_msg_output = String::from(expected_output);
 
         // Actual

--- a/cli/src/modules/log.rs
+++ b/cli/src/modules/log.rs
@@ -80,7 +80,7 @@ pub fn init_logger(pattern: &str) -> () {
     let verbosity: u32 = pattern.parse::<u32>().unwrap();
 
     match setup_logger(verbosity) {
-        Ok(verbosity) => { info!("Success initializing Rust Logger to verbosity level: {:?}", verbosity); () }
+        Ok(_) => { info!("Success initializing Rust Logger to verbosity level: {:?}", verbosity); () }
         Err(e) => { error!("Error initializing Rust Logger: {}", e); }
     }
 }

--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -11,8 +11,6 @@ use std::process;
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
     println!("Processing arguments: {:?}", args);
-    let trace_log_level: &str = &String::from("4");
-    diamond_drops_cli::modules::log::init_logger(&trace_log_level);
     diamond_drops_env::config::set_test_env();
     let config = diamond_drops_cli::modules::args::parse_cli_args(args)
         .unwrap_or_else(|err| {

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -2,6 +2,11 @@ extern crate diamond_drops;
 extern crate diamond_drops_cli as cli;
 extern crate diamond_drops_env as env;
 
+#[macro_use]
+extern crate clap;
+
+use clap::{App, Arg, SubCommand};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9,8 +14,16 @@ mod tests {
     #[test]
     fn it_does_not_panic_running_client_mode_with_proposer() {
         env::config::set_test_env();
-        let test_args_short = vec![String::from("-mode"), String::from("p")];
-        let config_short = cli::modules::args::parse_cli_args(test_args_short).unwrap();
+        let matches_short = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("proposer")
+                    .short("p")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "-p"
+            ]);
+        let test_args_short = matches_short;
+        let config_short = cli::modules::args::process_mode_matches(&test_args_short).unwrap();
         let result = diamond_drops::run(config_short);
 
         assert_eq!(result, ());
@@ -19,8 +32,16 @@ mod tests {
     #[test]
     fn it_does_not_panic_running_client_mode_with_notary() {
         env::config::set_test_env();
-        let test_args_short = vec![String::from("-mode"), String::from("n")];
-        let config_short = cli::modules::args::parse_cli_args(test_args_short).unwrap();
+        let matches_short = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("notary")
+                    .short("n")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "-n"
+            ]);
+        let test_args_short = matches_short;
+        let config_short = cli::modules::args::process_mode_matches(&test_args_short).unwrap();
         let result = diamond_drops::run(config_short);
 
         assert_eq!(result, ());
@@ -29,8 +50,17 @@ mod tests {
     #[test]
     fn it_does_not_panic_running_client_mode_with_both() {
         env::config::set_test_env();
-        let test_args_short = vec![String::from("-mode"), String::from("b")];
-        let config_short = cli::modules::args::parse_cli_args(test_args_short).unwrap();
+        env::config::set_test_env();
+        let matches_short = App::new("diamond-drops-cli")
+            .subcommand(SubCommand::with_name("mode")
+                .arg(Arg::with_name("both")
+                    .short("b")
+                ))
+            .get_matches_from(vec![
+                "diamond-drops-cli", "mode", "-b"
+            ]);
+        let test_args_short = matches_short;
+        let config_short = cli::modules::args::process_mode_matches(&test_args_short).unwrap();
         let result = diamond_drops::run(config_short);
 
         assert_eq!(result, ());


### PR DESCRIPTION
We've not integrated Clap into the CLI, which includes an in-built Help menu for Commands (i.e. Log, which is optional) `cargo run -- --log 4` and Sub-Commands (i.e. Mode, which may be used in conjunction with a Command). 
We can use Cargo Make to conveniently check everything is working still in the Main Package and all Libraries with:
  * Check that all tests are passing with `cargo make test-all`
  * Check that all different kinds of commands work without any errors with `cargo make all`

We can see the Help menu for all Commands with: `cargo run -- help`
We can see the Help menu for the "mode" SubCommand with: `cargo run -- mode --help`

Below are different combinations you can use, which the Help menu's will explain anyway:
```bash
cargo run -- help
cargo run -- --help
cargo run -- mode --help
cargo run -- --log 4 
cargo run -- --log 4 mode --help
cargo run -- --log 4 mode --proposer
cargo run -- --log 4 mode --notary
cargo run -- --log 4 mode --both
```

```bash
cargo run -- -l 4 mode -p
cargo run -- -l 4 mode -n
cargo run -- -l 4 mode -b
```

The last three commands above are equivalent to the following three commands respectively:

```bash
cargo run --bin cli -- -l 4 mode -p
cargo run --bin cli -- -l 4 mode -n
cargo run --bin cli -- -l 4 mode -b
```