### PR TITLE
refactor: Declare Type Alias for primitive types. All tests passing

### DIFF
--- a/node/src/modules/client_thread.rs
+++ b/node/src/modules/client_thread.rs
@@ -1,7 +1,5 @@
 use cli::modules::{config};
-use modules::notary;
-use modules::proposer;
-use modules::message;
+use modules::{notary, proposer, message};
 
 use std::sync::mpsc;
 use std::thread;

--- a/node/src/modules/collation/collation.rs
+++ b/node/src/modules/collation/collation.rs
@@ -1,5 +1,4 @@
-use modules::collation::header;
-use modules::collation::body;
+use modules::collation::{header, body};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Collation {

--- a/node/src/modules/collation/header.rs
+++ b/node/src/modules/collation/header.rs
@@ -1,27 +1,39 @@
 use ethereum_types;
+
+use modules::primitives::{
+    ShardIdHash,
+    ChunkRootHash,
+    ChunkPeriodHash,
+    ProposerAddress,
+    CollationHeaderHash,
+    ParentCollationHeaderHash,
+    ProposerBidHash,
+    ProposerSignature
+};
+
 use tiny_keccak;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Header {
-    shard_id: ethereum_types::U256,
-    proposer_address: ethereum_types::Address,
-    chunk_root: ethereum_types::H256,
-    period: ethereum_types::U256,
+    shard_id: ShardIdHash,
+    proposer_address: ProposerAddress,
+    chunk_root: ChunkRootHash,
+    period: ChunkPeriodHash,
 
     // The following fields are pending updates to the sharding spec and are currently ignored
-    //parent_hash: ethereum_types::H256,
-    //proposer_bid: ethereum_types::U256,
-    //proposer_signature: ethereum_types::Signature
+    //parent_hash: ParentCollationHeaderHash,
+    //proposer_bid: ProposerBidHash,
+    //proposer_signature: ProposerSignature
 }
 
 impl Header {
-    pub fn new(shard_id: ethereum_types::U256,
-               //parent_hash: ethereum_types::H256,
-               chunk_root: ethereum_types::H256,
-               period: ethereum_types::U256,
-               proposer_address: ethereum_types::Address,
-               //proposer_bid: ethereum_types::U256,
-               /*proposer_signature: ethereum_types::Signature*/) -> Header {
+    pub fn new(shard_id: ShardIdHash,
+               //parent_hash: ParentCollationHeaderHash,
+               chunk_root: ChunkRootHash,
+               period: ChunkPeriodHash,
+               proposer_address: ProposerAddress,
+               //proposer_bid: ProposerBidHash,
+               /*proposer_signature: ProposerSignature*/) -> Header {
         
         Header {
             shard_id,
@@ -34,7 +46,7 @@ impl Header {
         }
     }
 
-    pub fn hash(&self) -> ethereum_types::H256 {
+    pub fn hash(&self) -> CollationHeaderHash {
         let mut sha3 = tiny_keccak::Keccak::new_sha3_256();
         
         // Add the shard id
@@ -66,7 +78,7 @@ impl Header {
         let mut result_bytes: [u8; 32] = [0; 32];
         sha3.finalize(&mut result_bytes);
 
-        ethereum_types::H256::from_slice(&result_bytes[..])
+        CollationHeaderHash::from_slice(&result_bytes[..])
     }
 }
 
@@ -88,7 +100,7 @@ mod tests {
     fn it_produces_correct_hash() {
         // Build the args for collation header creation
         // Shard Id
-        let shard_id = ethereum_types::U256::from_dec_str("1").unwrap();
+        let shard_id = ShardIdHash::from_dec_str("1").unwrap();
         let shard_id_bytes = u256_to_bytes32(shard_id);
         
         /*
@@ -97,7 +109,7 @@ mod tests {
                                            0x54, 0x14, 0x7a, 0xd2, 0x89, 0x61, 0x75, 0xb0, 
                                            0x7d, 0x43, 0x7f, 0x9e, 0x58, 0xfa, 0x3c, 0x44, 
                                            0x86, 0xc0, 0x42, 0xf4, 0xc3, 0xd5, 0x05, 0x9b];
-        let parent_hash = ethereum_types::H256::from_slice(&parent_hash_bytes[..]);
+        let parent_hash = ParentCollationHeaderHash::from_slice(&parent_hash_bytes[..]);
         */
 
         // Chunk Root
@@ -105,10 +117,10 @@ mod tests {
                                           0x65, 0x25, 0xc2, 0xa0, 0x39, 0xa3, 0xa9, 0x95,
                                           0x34, 0x90, 0x35, 0xb2, 0xa8, 0x23, 0xa4, 0x99,
                                           0x0b, 0x27, 0xf6, 0xd7, 0xd5, 0x5e, 0xec, 0x6b];
-        let chunk_root = ethereum_types::H256::from_slice(&chunk_root_bytes[..]);
+        let chunk_root = ChunkRootHash::from_slice(&chunk_root_bytes[..]);
 
         // Period
-        let period = ethereum_types::U256::from_dec_str("1").unwrap();
+        let period = ChunkPeriodHash::from_dec_str("1").unwrap();
         let period_bytes = u256_to_bytes32(period);
 
         // Proposer Address
@@ -116,13 +128,13 @@ mod tests {
                                                 0x52, 0x96, 0xab, 0x98, 0x52, 
                                                 0x3b, 0x1a, 0x3d, 0xef, 0x8f, 
                                                 0x18, 0x67, 0xad, 0x32, 0xb0];
-        let proposer_address = ethereum_types::H160::from_slice(&proposer_address_bytes[..]);
+        let proposer_address = ProposerAddress::from_slice(&proposer_address_bytes[..]);
 
         // Create the header
         let header = Header::new(shard_id, /*parent_hash,*/ chunk_root, period, proposer_address);
 
         // Calculate its generated hash
-        let header_hash = header.hash();
+        let header_hash: CollationHeaderHash = header.hash();
 
         // Calculate the expected hash
         let mut sha3 = tiny_keccak::Keccak::new_sha3_256();
@@ -135,7 +147,7 @@ mod tests {
         let mut expected_bytes: [u8; 32] = [0; 32];
         sha3.finalize(&mut expected_bytes);
 
-        let expected = ethereum_types::H256::from_slice(&expected_bytes[..]);
+        let expected: CollationHeaderHash = CollationHeaderHash::from_slice(&expected_bytes[..]);
 
         // Ensure manually calculated hash matches the generated hash
         assert_eq!(expected, header_hash);

--- a/node/src/modules/message.rs
+++ b/node/src/modules/message.rs
@@ -1,13 +1,11 @@
 use modules::collation::collation;
-
-use ethereum_types;
-
+use modules::primitives::{ShardIdHash};
 
 #[derive(Debug)]
 /// A message from the SMC Listener
 pub enum Message {
     Selected{value: bool},
-    ShardId{value: ethereum_types::U256},
+    ShardId{value: ShardIdHash},
     Collation{value: collation::Collation},
     Proposal{value: collation::Collation}
 }

--- a/node/src/modules/mod.rs
+++ b/node/src/modules/mod.rs
@@ -4,3 +4,4 @@ pub mod message;
 pub mod notary;
 pub mod proposer;
 pub mod smc_listener;
+pub mod primitives;

--- a/node/src/modules/notary.rs
+++ b/node/src/modules/notary.rs
@@ -1,19 +1,24 @@
 use modules::collation::collation;
 use modules::message;
 use modules::client_thread;
-
-use ethereum_types;
+use modules::primitives::{
+    ShardIdHash,
+    ChunkRootHash,
+    ChunkPeriodHash,
+    NotaryIdHash,
+    ProposerAddress
+};
 
 use std::thread;
 use std::sync::mpsc;
 use std::collections::HashMap;
 
 pub struct Notary {
-    id: ethereum_types::U256,
+    id: NotaryIdHash,
     selected: bool,
-    shard_id: ethereum_types::U256,
-    collation_vectors: HashMap<ethereum_types::U256, Vec<collation::Collation>>,
-    proposal_vectors: HashMap<ethereum_types::U256, Vec<collation::Collation>>,
+    shard_id: ShardIdHash,
+    collation_vectors: HashMap<ShardIdHash, Vec<collation::Collation>>,
+    proposal_vectors: HashMap<ShardIdHash, Vec<collation::Collation>>,
     smc_listener: mpsc::Receiver<message::Message>,
     manager_listener: mpsc::Receiver<client_thread::Command>
 }
@@ -31,9 +36,9 @@ impl Notary {
     pub fn new(smc_listener: mpsc::Receiver<message::Message>, 
                manager_listener: mpsc::Receiver<client_thread::Command>) -> Notary {
         Notary {
-            id: ethereum_types::U256::from_dec_str("0").unwrap(),
+            id: NotaryIdHash::from_dec_str("0").unwrap(),
             selected: false,
-            shard_id: ethereum_types::U256::from_dec_str("0").unwrap(),
+            shard_id: ShardIdHash::from_dec_str("0").unwrap(),
             collation_vectors: HashMap::new(),
             proposal_vectors: HashMap::new(),
             smc_listener,
@@ -115,18 +120,18 @@ mod tests {
     use modules::collation::header;
     use modules::collation::body;
 
-    fn generate_genesis_collation(shard_id: ethereum_types::U256) -> collation::Collation {
-        let chunk_root = ethereum_types::H256::zero();
-        let period = ethereum_types::U256::from_dec_str("0").unwrap();
-        let proposer_address = ethereum_types::Address::zero();
+    fn generate_genesis_collation(shard_id: ShardIdHash) -> collation::Collation {
+        let chunk_root = ChunkRootHash::zero();
+        let period = ChunkPeriodHash::from_dec_str("0").unwrap();
+        let proposer_address = ProposerAddress::zero();
         let genesis_header = header::Header::new(shard_id, chunk_root, period, proposer_address);
         collation::Collation::new(genesis_header, body::Body)
     }
 
-    fn generate_collation(shard_id: ethereum_types::U256, 
-                          period: ethereum_types::U256) -> collation::Collation {
-        let chunk_root = ethereum_types::H256::zero();
-        let proposer_address = ethereum_types::Address::zero();
+    fn generate_collation(shard_id: ShardIdHash,
+                          period: ChunkPeriodHash) -> collation::Collation {
+        let chunk_root = ChunkRootHash::zero();
+        let proposer_address = ProposerAddress::zero();
         let collation_header = header::Header::new(shard_id, chunk_root, period, proposer_address);
         collation::Collation::new(collation_header, body::Body)
     }
@@ -143,14 +148,14 @@ mod tests {
 
         // Genesis collation
         let genesis_collation = generate_genesis_collation(
-            ethereum_types::U256::from_dec_str("0").unwrap());
+            ShardIdHash::from_dec_str("0").unwrap());
 
         let genesis_collation_cmp = genesis_collation.clone();
 
         // First collation
         let first_collation = generate_collation(
-            ethereum_types::U256::from_dec_str("0").unwrap(),
-            ethereum_types::U256::from_dec_str("1").unwrap()
+            ShardIdHash::from_dec_str("0").unwrap(),
+            ChunkPeriodHash::from_dec_str("1").unwrap()
         );
 
         let first_collation_cmp = first_collation.clone();
@@ -161,7 +166,7 @@ mod tests {
 
         // Check that the operations succeded
         let vector = notary.collation_vectors.get(
-            &ethereum_types::U256::from_dec_str("0").unwrap())
+            &ShardIdHash::from_dec_str("0").unwrap())
             .unwrap();
 
         assert_eq!(vector[0], genesis_collation_cmp);
@@ -174,8 +179,8 @@ mod tests {
 
         // Generate proposal
         let proposal = generate_collation(
-            ethereum_types::U256::from_dec_str("0").unwrap(),
-            ethereum_types::U256::from_dec_str("1").unwrap()
+            ShardIdHash::from_dec_str("0").unwrap(),
+            ChunkPeriodHash::from_dec_str("1").unwrap()
         );
         let proposal_cmp = proposal.clone();
 
@@ -184,7 +189,7 @@ mod tests {
 
         // Check that the operations succeeded
         let vector = notary.proposal_vectors.get(
-            &ethereum_types::U256::from_dec_str("0").unwrap())
+            &ShardIdHash::from_dec_str("0").unwrap())
             .unwrap();
 
         assert_eq!(vector[0], proposal_cmp);

--- a/node/src/modules/primitives.rs
+++ b/node/src/modules/primitives.rs
@@ -1,0 +1,18 @@
+use ethereum_types;
+
+/// Advanced types used to create an aliases
+pub type ShardIdHash = ethereum_types::U256;
+pub type ChunkRootHash = ethereum_types::H256;
+pub type ChunkPeriodHash = ethereum_types::U256;
+
+pub type ProposerIdHash = ethereum_types::U256;
+pub type NotaryIdHash = ethereum_types::U256;
+
+pub type ProposerAddress = ethereum_types::Address; // ethereum_types::H160;
+pub type NotaryAddress = ethereum_types::Address; // ethereum_types::H160;
+
+pub type CollationHeaderHash = ethereum_types::H256;
+pub type ParentCollationHeaderHash = ethereum_types::H256;
+
+pub type ProposerBidHash = ethereum_types::U256;
+pub type ProposerSignature = ethereum_types::Signature;

--- a/node/src/modules/proposer.rs
+++ b/node/src/modules/proposer.rs
@@ -1,13 +1,13 @@
-use ethereum_types;
+use modules::primitives::ProposerIdHash;
 
 pub struct Proposer {
-    id: ethereum_types::U256
+    id: ProposerIdHash
 }
 
 impl Proposer {
     pub fn new() -> Proposer {
         Proposer {
-            id: ethereum_types::U256::from_dec_str("0").unwrap()
+            id: ProposerIdHash::from_dec_str("0").unwrap()
         }
     }
 

--- a/node/src/modules/smc_listener.rs
+++ b/node/src/modules/smc_listener.rs
@@ -1,12 +1,16 @@
 use modules::message;
-
-use ethereum_types;
+use modules::primitives::{
+    ShardIdHash,
+    ChunkPeriodHash,
+    NotaryAddress,
+    ProposerAddress
+};
 
 use std::sync::mpsc;
 
 /// This will monitor the SMC for changes and then send relevant information to the notary or the proposer.
 pub struct SMCListener {
-    period: ethereum_types::U256,
+    period: ShardIdHash,
     notary_sender: mpsc::Sender<message::Message>
 }
 
@@ -14,12 +18,12 @@ impl SMCListener {
     /// Creates a new SMC Listener
     pub fn new(notary_sender: mpsc::Sender<message::Message>) -> SMCListener {
         SMCListener {
-            period: ethereum_types::U256::from_dec_str("0").unwrap(),
+            period: ChunkPeriodHash::from_dec_str("0").unwrap(),
             notary_sender
         }
     }
 
-    fn register_notary_address(&self, notary_addr: ethereum_types::Address) -> bool {
+    fn register_notary_address(&self, notary_addr: NotaryAddress) -> bool {
         // TODO - Implement registration of notary address in notary registry of SMC Contract
         let result: Result<String, String> = Result::Err(String::from("Error"));
 
@@ -29,11 +33,11 @@ impl SMCListener {
         }
     }
 
-    fn get_selected_notaries(&self, shard_id: ethereum_types::U256) -> Vec<ethereum_types::Address> {
-        vec![ethereum_types::Address::zero()]
+    fn get_selected_notaries(&self, shard_id: ShardIdHash) -> Vec<NotaryAddress> {
+        vec![NotaryAddress::zero()]
     }
 
-    fn register_proposer_address(&self, proposer_addr: ethereum_types::Address) -> bool {
+    fn register_proposer_address(&self, proposer_addr: ProposerAddress) -> bool {
         // TODO - Implement registration of proposer address in proposer registry of SMC Contract
         let result: Result<String, String> = Result::Err(String::from("Error"));
 
@@ -57,7 +61,7 @@ mod tests {
                                            0x82, 0xc1, 0x19, 0x77, 0x36, 
                                            0xb3, 0xfC, 0xe3, 0x4a, 0xD4, 
                                            0xFc, 0x5e, 0xEe, 0x75, 0xc8];
-        let notary_addr: ethereum_types::Address = ethereum_types::Address::from_slice(&notary_addr_bytes);
+        let notary_addr: NotaryAddress = NotaryAddress::from_slice(&notary_addr_bytes);
         let result = smc.register_notary_address(notary_addr);
         assert_eq!(true, result);
     }
@@ -71,7 +75,7 @@ mod tests {
                                              0x82, 0xc1, 0x19, 0x77, 0x36, 
                                              0xb3, 0xfC, 0xe3, 0x4a, 0xD4, 
                                              0xFc, 0x5e, 0xEe, 0x75, 0xc8];
-        let proposer_addr: ethereum_types::Address = ethereum_types::Address::from_slice(&proposer_addr_bytes);
+        let proposer_addr: ProposerAddress = ProposerAddress::from_slice(&proposer_addr_bytes);
         let result = smc.register_proposer_address(proposer_addr);
         assert_eq!(true, result);
     }
@@ -81,7 +85,7 @@ mod tests {
     fn it_gets_selected_notaries() {
         let (tx, rx) = mpsc::channel();
         let smc = SMCListener::new(tx);
-        let shard_id = ethereum_types::U256::from_dec_str("0").unwrap();
+        let shard_id = ShardIdHash::from_dec_str("0").unwrap();
         let notary_addr = smc.get_selected_notaries(shard_id);
 
         // The dummy "selected notary"
@@ -89,7 +93,7 @@ mod tests {
                                            0x24, 0xA8, 0xaf, 0xC2, 0xb1, 
                                            0x57, 0xCe, 0xbA, 0x3c, 0xDd, 
                                            0x2a, 0x27, 0xc4, 0xE2, 0x1f];
-        let selected_notary_addr = ethereum_types::Address::from_slice(&notary_addr_bytes);
+        let selected_notary_addr: NotaryAddress = NotaryAddress::from_slice(&notary_addr_bytes);
 
         assert_eq!(vec![selected_notary_addr], notary_addr);
     }


### PR DESCRIPTION
References:
*  https://github.com/rust-lang/book/blob/master/2018-edition/src/ch19-04-advanced-types.md#type-aliases-create-type-synonyms
* https://github.com/paritytech/polkadot/blob/master/demo/primitives/src/lib.rs